### PR TITLE
Add chatgpt_basic_query, chatgpt_persistance, and chatgpt_stream examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rust-chatgpt-cli"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = "4.2.4"
+reqwest = { version = "0.11", features = ["json", "stream"] }
+tokio = { version = "1", features = ["full"] }
+serde_json = "1.0"
+futures-util = "0.3"
+chatgpt_rs = { version = "1.1.3", features = ["streams", "postcard", "json"] }

--- a/src/bin/chatgpt_basic_query.rs
+++ b/src/bin/chatgpt_basic_query.rs
@@ -1,0 +1,20 @@
+use std::env;
+
+use chatgpt::prelude::ChatGPT;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // get api key or exit
+    let api_key = env::var("OPENAI_API_KEY").expect("Missing OPENAI_API_KEY environment variable");
+
+    // create a cilent
+    let client = ChatGPT::new(api_key)?;
+
+    // query chatgpt
+    let response = client
+        .send_message("whats the meaning of life? answer with just a number.")
+        .await?;
+    println!("Response: {:}", response.message().content);
+
+    Ok(())
+}

--- a/src/bin/chatgpt_persistance.rs
+++ b/src/bin/chatgpt_persistance.rs
@@ -1,0 +1,56 @@
+use std::env;
+use std::{fs, io, path::Path};
+
+use chatgpt::prelude::ChatGPT;
+
+const CONVERSATION_DIR: &str = ".conversations";
+const TEST_CONVERSATION_FILE: &str = ".conversations/test-conversation.bin";
+
+fn handle_conversation_save_dir() -> io::Result<()> {
+    if !Path::new(CONVERSATION_DIR).exists() {
+        fs::create_dir(CONVERSATION_DIR)?;
+    }
+    if Path::new(TEST_CONVERSATION_FILE).exists() {
+        fs::remove_file(TEST_CONVERSATION_FILE)?;
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // get api key or exit
+    let api_key = env::var("OPENAI_API_KEY").expect("Missing OPENAI_API_KEY environment variable");
+
+    // create a cilent
+    let client = ChatGPT::new(api_key)?;
+
+    // create a conversation
+    let mut conversation = client.new_conversation();
+    conversation
+        .send_message("Explain technical analysis in 10 words")
+        .await?;
+    conversation
+        .send_message("Please do the same for fundemental analysis")
+        .await?;
+
+    // persist the conversation
+    handle_conversation_save_dir()?;
+    conversation
+        .save_history_postcard(&TEST_CONVERSATION_FILE)
+        .await?;
+    // get rid of conversation since we will create a new one
+    drop(conversation);
+
+    let mut new_conversation = client
+        .restore_conversation_postcard(&TEST_CONVERSATION_FILE)
+        .await?;
+    let response = new_conversation
+        .send_message("Now do the same for value investing")
+        .await?;
+
+    for message in &new_conversation.history {
+        println!("{:?}: {:}", message.role, message.content);
+    }
+
+    Ok(())
+}

--- a/src/bin/chatgpt_stream.rs
+++ b/src/bin/chatgpt_stream.rs
@@ -1,0 +1,35 @@
+use chatgpt::prelude::{ChatGPT, ResponseChunk};
+use futures_util::StreamExt;
+use std::env;
+use std::io::{stdout, Write};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // get api key or exit
+    let api_key = env::var("OPENAI_API_KEY").expect("Missing OPENAI_API_KEY environment variable");
+
+    // create a cilent
+    let client = ChatGPT::new(api_key)?;
+
+    // query chatgpt
+    let stream = client
+        .send_message_streaming("explain github to me like I am a five year old, under 10 words.")
+        .await?;
+
+    stream
+        .for_each(|response_token| async move {
+            match response_token {
+                ResponseChunk::Content {
+                    delta,
+                    response_index: _,
+                } => {
+                    print!("{delta}");
+                    stdout().lock().flush().unwrap();
+                }
+                _ => {}
+            }
+        })
+        .await;
+
+    Ok(())
+}


### PR DESCRIPTION
## Description:

This PR adds three new examples to demonstrate the usage of chatgpt_rs library with chatgpt-cli. These examples will help users better understand how to integrate the library into their projects and take advantage of its features.

## New Examples:

chatgpt_basic_query.rs: A simple example that demonstrates how to make a basic query to ChatGPT using the chatgpt_rs library. This will help users get started with the most basic functionality of the library.

chatgpt_persistance.rs: This example showcases how to maintain conversation persistence with the ChatGPT model using chatgpt_rs. It demonstrates how to manage conversation history and maintain context throughout multiple exchanges with the chatbot.

chatgpt_stream.rs: This example demonstrates the streaming functionality provided by the chatgpt_rs library. It shows users how to use streaming to efficiently generate responses from ChatGPT, allowing for more interactive and real-time conversations.

## Updates:

The Cargo.toml file has been updated to include the chatgpt_rs dependency and related features needed for the new examples.

--- 
By providing these examples, we aim to help developers quickly understand how to use the chatgpt_rs library and its features, enabling them to create more advanced applications with ChatGPT.