### PR TITLE
Implement basic chatbot query functionality and command-line interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+
+# Added by cargo
+
+/target

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
-
 # Added by cargo
 
 /target

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,4 @@ Cargo.lock
 *.pdb
 
 # Added by cargo
-
 /target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "4.2.4"
+clap = "3.0.0-beta.5"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1.0"
 futures-util = "0.3"
 chatgpt_rs = { version = "1.1.3", features = ["streams", "postcard", "json"] }
+atty = "0.2.14"

--- a/src/bin/argument_extraction.rs
+++ b/src/bin/argument_extraction.rs
@@ -25,7 +25,7 @@ fn main() {
         .about("A chatbot application")
         .arg(
             Arg::with_name("prompt")
-                .help("Provide a prompt for the chatbot")
+                .help("Enter your prompt:")
                 .multiple_values(true)
                 .index(1)
                 .required(false),

--- a/src/bin/argument_extraction.rs
+++ b/src/bin/argument_extraction.rs
@@ -59,7 +59,7 @@ fn main() {
     // Handle the different argument scenarios
     if matches.is_present("list") {
         // List all conversations
-        println!("Listing all conversations...");
+        println!("Listing conversations...");
     } else if matches.is_present("del") {
         // Delete a conversation by index
         let index = matches.value_of("del").expect("Missing conversation index");

--- a/src/bin/argument_extraction.rs
+++ b/src/bin/argument_extraction.rs
@@ -49,7 +49,7 @@ fn main() {
             Arg::with_name("del")
                 .short('d')
                 .long("del")
-                .help("Delete a conversation by index")
+                .help("Delete a convo by INDEX")
                 .takes_value(true)
                 .value_name("INDEX")
                 .conflicts_with_all(&["prompt", "new-conversation", "list"]),

--- a/src/bin/argument_extraction.rs
+++ b/src/bin/argument_extraction.rs
@@ -1,0 +1,83 @@
+use atty::Stream;
+use clap::{App, Arg};
+use std::io::{self, Read};
+
+fn main() {
+    let mut stdin_prompt = String::new();
+
+    // Check if stdin has data (e.g., "cat some-file | chatgpt")
+    if !atty::is(Stream::Stdin) {
+        let mut stdin_contents = String::new();
+        let mut stdin = io::stdin();
+        let stdin_result = stdin.read_to_string(&mut stdin_contents);
+
+        if stdin_result.is_ok() {
+            let contents = stdin_contents.trim();
+            if !contents.is_empty() {
+                println!("Handling prompt from stdin: {}", contents);
+                stdin_prompt = contents.to_string();
+            }
+        }
+    }
+
+    println!("stdin_prompt is_empty: {:?}", stdin_prompt.is_empty());
+    let matches = App::new("chatgpt")
+        .about("A chatbot application")
+        .arg(
+            Arg::with_name("prompt")
+                .help("Provide a prompt for the chatbot")
+                .multiple_values(true)
+                .index(1)
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("new-conversation")
+                .short('n')
+                .long("new-conversation")
+                .help("Start a new conversation")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("list")
+                .short('l')
+                .long("list")
+                .help("List all conversations")
+                .takes_value(false)
+                .conflicts_with_all(&["prompt", "new-conversation", "del"]),
+        )
+        .arg(
+            Arg::with_name("del")
+                .short('d')
+                .long("del")
+                .help("Delete a conversation by index")
+                .takes_value(true)
+                .value_name("INDEX")
+                .conflicts_with_all(&["prompt", "new-conversation", "list"]),
+        )
+        .get_matches();
+
+    // Handle the different argument scenarios
+    if matches.is_present("list") {
+        // List all conversations
+        println!("Listing all conversations...");
+    } else if matches.is_present("del") {
+        // Delete a conversation by index
+        let index = matches.value_of("del").expect("Missing conversation index");
+        println!("Deleting conversation with index {}...", index);
+    } else {
+        // Process the chatbot prompt
+        let mut prompt = if stdin_prompt.is_empty() {
+            matches
+                .values_of("prompt")
+                .map(|prompt_values| prompt_values.collect::<Vec<_>>().join(" "))
+                .unwrap_or_else(|| String::new())
+        } else {
+            stdin_prompt
+        };
+        let new_conversation = matches.is_present("new-conversation");
+        println!(
+            "Processing prompt: '{}', new conversation: {}",
+            prompt, new_conversation
+        );
+    }
+}

--- a/src/conversation.rs
+++ b/src/conversation.rs
@@ -1,0 +1,18 @@
+use chatgpt::prelude::ChatGPT;
+use std::env;
+
+#[tokio::main]
+pub async fn basic_query(prompt: String) -> Result<String, Box<dyn std::error::Error>> {
+    // get api key or exit
+    let api_key = env::var("OPENAI_API_KEY").expect("Missing OPENAI_API_KEY environment variable");
+
+    // create a cilent
+    let client = ChatGPT::new(api_key)?;
+
+    // query chatgpt
+    let response = client.send_message(prompt).await?;
+    let content = &response.message().content;
+    println!("Response: {:}", &content);
+
+    Ok(content.clone())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod conversation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,93 @@
+use atty::Stream;
+use clap::{App, Arg, ArgMatches};
+use rust_chatgpt_cli::conversation::basic_query;
+use std::io::{self, Read};
+
+fn check_stdin() -> String {
+    let mut stdin_prompt = String::new();
+    // Check if stdin has data (e.g., "cat some-file | chatgpt")
+    if !atty::is(Stream::Stdin) {
+        let mut stdin_contents = String::new();
+        let mut stdin = io::stdin();
+        let stdin_result = stdin.read_to_string(&mut stdin_contents);
+
+        if stdin_result.is_ok() {
+            let contents = stdin_contents.trim();
+            if !contents.is_empty() {
+                println!("Handling prompt from stdin: {}", contents);
+                stdin_prompt = contents.to_string();
+            }
+        }
+    }
+    stdin_prompt
+}
+
+fn configure_application() -> ArgMatches {
+    App::new("chatgpt")
+        .about("A chatbot application")
+        .arg(
+            Arg::with_name("prompt")
+                .help("Provide a prompt for the chatbot")
+                .multiple_values(true)
+                .index(1)
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("new-conversation")
+                .short('n')
+                .long("new-conversation")
+                .help("Start a new conversation")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("list")
+                .short('l')
+                .long("list")
+                .help("List all conversations")
+                .takes_value(false)
+                .conflicts_with_all(&["prompt", "new-conversation", "del"]),
+        )
+        .arg(
+            Arg::with_name("del")
+                .short('d')
+                .long("del")
+                .help("Delete a conversation by index")
+                .takes_value(true)
+                .value_name("INDEX")
+                .conflicts_with_all(&["prompt", "new-conversation", "list"]),
+        )
+        .get_matches()
+}
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let stdin_prompt = check_stdin();
+
+    let matches = configure_application();
+
+    // Handle the different argument scenarios
+    if matches.is_present("list") {
+        // List all conversations
+        println!("Listing all conversations...");
+    } else if matches.is_present("del") {
+        // Delete a conversation by index
+        let index = matches.value_of("del").expect("Missing conversation index");
+        println!("Deleting conversation with index {}...", index);
+    } else {
+        // Process the chatbot prompt
+        let prompt = if stdin_prompt.is_empty() {
+            matches
+                .values_of("prompt")
+                .map(|prompt_values| prompt_values.collect::<Vec<_>>().join(" "))
+                .unwrap_or_else(|| String::new())
+        } else {
+            stdin_prompt
+        };
+
+        let new_conversation = matches.is_present("new-conversation");
+        println!(
+            "Processing prompt: '{}', new conversation: {}",
+            &prompt, new_conversation
+        );
+        println!("{:}", basic_query(prompt)?);
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn configure_application() -> ArgMatches {
         .about("A chatbot application")
         .arg(
             Arg::with_name("prompt")
-                .help("Provide a prompt for the chatbot")
+                .help("Enter your prompt")
                 .multiple_values(true)
                 .index(1)
                 .required(false),
@@ -51,7 +51,7 @@ fn configure_application() -> ArgMatches {
             Arg::with_name("del")
                 .short('d')
                 .long("del")
-                .help("Delete a conversation by index")
+                .help("Delete a convo by INDEX")
                 .takes_value(true)
                 .value_name("INDEX")
                 .conflicts_with_all(&["prompt", "new-conversation", "list"]),
@@ -66,7 +66,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Handle the different argument scenarios
     if matches.is_present("list") {
         // List all conversations
-        println!("Listing all conversations...");
+        println!("Listing conversations...");
     } else if matches.is_present("del") {
         // Delete a conversation by index
         let index = matches.value_of("del").expect("Missing conversation index");


### PR DESCRIPTION
## Description

This PR introduces the following changes:

- Adds a new `conversation.rs` file that contains the `basic_query` function for querying ChatGPT.
- Creates a new `lib.rs` file to define the `conversation` module.
- Introduces a new `main.rs` file, which handles command-line arguments and calls the `basic_query` function for processing chatbot prompts.
- Utilizes the `clap` crate for parsing command-line arguments and the `atty`
