### PR TITLE
feat(macros): add debug_println and debug_print macros

### DIFF
--- a/src/chatgpt.rs
+++ b/src/chatgpt.rs
@@ -1,4 +1,5 @@
 use crate::chatgpt_client_wrapper::{ChatGPTClient, ChatGPTClientWrapper};
+use crate::debug_println;
 
 pub struct ChatGPT {}
 impl ChatGPT {
@@ -8,7 +9,7 @@ impl ChatGPT {
         let response_future = client.send_message(prompt.to_owned());
         let response = Box::pin(response_future).await?;
         let content = response.message_choices[0].message.content.clone();
-        println!("Response: {:}", content);
+        debug_println!("Response: {:}", content);
 
         Ok(content)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub use chatgptlib::prelude::{
 pub use chatgptlib::types::CompletionResponse;
 pub mod chatgpt;
 pub mod chatgpt_client_wrapper;
+pub mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,17 @@
+#[macro_export]
+macro_rules! debug_println {
+    ($($arg:tt)*) => {
+        if std::env::var("ENABLE_DEBUG_PRINT").ok() == Some(String::from("1")) {
+            println!($($arg)*);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! debug_print {
+    ($($arg:tt)*) => {
+        if std::env::var("ENABLE_DEBUG_PRINT").ok() == Some(String::from("1")) {
+            print!($($arg)*);
+        }
+    };
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use atty::Stream;
 use clap::{App, Arg, ArgMatches};
 use rust_chatgpt_cli::chatgpt::ChatGPT;
+use rust_chatgpt_cli::debug_println;
 use std::io::{self, Read};
 
 fn check_stdin() -> String {
@@ -14,7 +15,7 @@ fn check_stdin() -> String {
         if stdin_result.is_ok() {
             let contents = stdin_contents.trim();
             if !contents.is_empty() {
-                println!("Handling prompt from stdin: {}", contents);
+                debug_println!("Handling prompt from stdin: {}", contents);
                 stdin_prompt = contents.to_string();
             }
         }
@@ -68,11 +69,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Handle the different argument scenarios
     if matches.is_present("list") {
         // List all conversations
-        println!("Listing conversations...");
+        debug_println!("Listing conversations...");
     } else if matches.is_present("del") {
         // Delete a conversation by index
         let index = matches.value_of("del").expect("Missing conversation index");
-        println!("Deleting conversation with index {}...", index);
+        debug_println!("Deleting conversation with index {}...", index);
     } else {
         // Process the chatbot prompt
         let prompt = if stdin_prompt.is_empty() {
@@ -85,9 +86,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         let new_conversation = matches.is_present("new-conversation");
-        println!(
+        debug_println!(
             "Processing prompt: '{}', new conversation: {}",
-            &prompt, new_conversation
+            &prompt,
+            new_conversation
         );
         println!("{:}", ChatGPT::basic_query(&prompt).await?);
     }


### PR DESCRIPTION
Add two new macros, `debug_println` and `debug_print`, to allow for conditional printing of debug information. These macros will only print if the `ENABLE_DEBUG_PRINT` environment variable is set to `"1"`. This will make it easier to debug the codebase without cluttering the output with unnecessary information.