### PR TITLE
feat(release): add support for universal macOS binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,101 +1,47 @@
 name: Release
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:
       - 'v*'
 
 jobs:
-  build-and-release:
-    runs-on: ${{ matrix.os }}
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          # (required) GitHub token for creating GitHub Releases.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-assets:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: macos-latest
-            target: x86_64-apple-darwin
-          - os: macos-latest
-            target: aarch64-apple-darwin
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          # Universal macOS binary is supported as universal-apple-darwin.
+          - target: universal-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: taiki-e/upload-rust-binary-action@v1
         with:
-          toolchain: stable
+          # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
+          # Note that glob pattern is not supported yet.
+          bin: rust-chatgpt-cli
+          # (optional) Target triple, default is host triple.
           target: ${{ matrix.target }}
-          profile: minimal
-          default: true
-
-      - name: Build and release
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target ${{ matrix.target }}
-
-      - name: Upload release artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: rust-chatgpt-cli-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/rust-chatgpt-cli*
-          if-no-files-found: error
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-
-      - name: Install deps
-        run: npm install @actions/glob
-      - name: Upload release assets
-        uses: actions/github-script@v5
-        with:
-          script: |
-            const fs = require('fs');
-            const globberModule = require('@actions/glob');
-            const { owner, repo } = context.repo;
-            const release_id = core.getInput('release_id', { required: true });
-
-            async function main() {
-              const artifact_glob = `target/${{ matrix.target }}/release/rust-chatgpt-cli*`;
-              const globber = await globberModule.create(artifact_glob);
-              const artifact_paths = await globber.glob();
-
-              for (const path of artifact_paths) {
-                const content_type = path.endsWith(".zip") ? "application/zip" : "application/octet-stream";
-                const file_name = path.split('/').pop();
-
-                console.log(`Uploading ${file_name}`);
-                const file = fs.readFileSync(path);
-
-                await github.repos.uploadReleaseAsset({
-                  owner,
-                  repo,
-                  release_id,
-                  name: file_name,
-                  data: file,
-                  headers: {
-                    'content-type': content_type,
-                    'content-length': file.length,
-                  },
-                });
-              }
-            }
-
-            main().catch(err => core.setFailed(err.message));
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          # (required) GitHub token for uploading assets to GitHub Releases.
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit adds support for building and uploading a universal macOS binary as part of the release process. The `upload-assets` job now includes a new target `universal-apple-darwin` and the `upload-rust-binary-action` has been updated to support building and uploading a universal binary.