### PR TITLE
build: remove aarch64-unknown-linux-gnu and universal-apple-darwin ta…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-apple-darwin
-            os: macos-latest
-          # Universal macOS binary is supported as universal-apple-darwin.
-          - target: universal-apple-darwin
             os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION

The aarch64-unknown-linux-gnu and universal-apple-darwin targets have been removed from the release.yml file to simplify the build process. This is a build commit and does not introduce any new features or fix any bugs.