### PR TITLE
chore: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,97 @@
 # Rust ChatGPT CLI
 
-Rust ChatGPT CLI is a command-line interface for interacting with OpenAI's GPT-based chatbot in the terminal. It enables users to start new conversations, manage ongoing conversations, and send text from a file to the chatbot using simple commands.
+## In use
 
-## Features
+[<img src="https://i.ytimg.com/vi/d-WKDH4-6sI/maxresdefault.jpg">](https://www.youtube.com/watch?v=d-WKDH4-6sI "Script Output")
 
-- Start a new conversation with the ChatGPT API by entering a message: `chatgpt new "your message"`
-- Send the contents of a file to the ChatGPT API: `cat file_with_contents | chatgpt new`
-- List all ongoing conversations: `chatgpt list`
-- Continue ongoing conversations: `chatgpt cont <index> "your new message"`
-- Delete a conversation based on its index: `chatgpt del <index>`
+# rust-chatgpt-cli
 
-## Prerequisites
+`rust-chatgpt-cli` is a command-line interface (CLI) application that allows you to interact with OpenAI's ChatGPT API. You can start new conversations, list and delete existing ones, and process chatbot prompts.
 
-- Rust programming language
+## Usage Instructions
+
+### Prerequisites
+
+- Rust installed on your system
 - OpenAI API Key
 
 ## Getting Started
 
-1. Clone the repository and navigate to the project directory.
+### Build and Run
+
+1. Clone this repository:
+```
+git clone https://github.com/yourusername/rust-chatgpt-cli.git
+```
+
 2. Set your OpenAI API key as an environment variable:
 ```shell
 export OPENAI_KEY=your_openai_key
 ```
 
-## Usage
-
-- Start a new conversation:
-```shell
-chatgpt new "your message"
+3. Navigate to the project directory:
+```
+cd rust-chatgpt-cli
 ```
 
-- Send the contents of a file to the ChatGPT API:
-```shell
-cat file_with_contents | chatgpt new
+4. Build the project:
+```
+cargo build --release
 ```
 
-- List all ongoing conversations:
-
-```shell
-chatgpt list
+5. Run the application:
+```
+./target/release/rust-chatgpt-cli [FLAGS] [OPTIONS]
 ```
 
-- Continue old conversation by using the index to refer to it.
-```shell
-chatgpt cont <index> "your message"
+### Flags and Options
+
+- `-n, --new-conversation`: Start a new conversation
+- `-l, --list`: List all conversations
+- `-d, --del INDEX`: Delete a conversation by its index
+- `prompt`: Enter your prompt (can be a single or multiple words)
+
+### Examples
+
+All the features with (🚧) are under still under construction.
+
+1. Start a new conversation (🚧):
+```
+./target/release/rust-chatgpt-cli -n What is the meaning of life?
 ```
 
-- Delete a conversation based on its index:
-```shell
-chatgpt del <index>
-
+2. List all conversations (🚧):
 ```
+./target/release/rust-chatgpt-cli -l
+```
+
+3. Delete a conversation by index (🚧):
+```
+./target/release/rust-chatgpt-cli -d 2
+```
+
+4. Provide a prompt:
+```
+./target/release/rust-chatgpt-cli Tell me a joke.
+```
+
+5. Use stdin for the prompt:
+```
+echo "What is your favorite color?" | ./target/release/rust-chatgpt-cli
+```
+
+6. Use a file to build your prompt, then pipe it to chatgpt.
+```shell
+$ cat > prompt
+You are a computer science lecturer at a university.
+You excel at explaining programming concepts to student.
+
+Could you please explain what a hashtable is?
+^C
+$ cat prompt | ./target/release/rust-chatgpt-cli
+```
+
+Note: (🚧) You can combine the `-n` flag with a prompt to start a new conversation with the given prompt.
 
 ## Contributing
 
@@ -58,4 +99,4 @@ Please feel free to open an issue or submit a pull request with your contributio
 
 ## License
 
-This project is licensed under the MIT License.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Updated the README.md file to include more detailed instructions on how to build and run the `rust-chatgpt-cli` application. Added examples of how to use the different flags and options available, and included a note about combining the `-n` flag with a prompt to start a new conversation with the given prompt. Also updated the license information.